### PR TITLE
Initialize CI to build images for workshop

### DIFF
--- a/.github/workflows/model-image.yml
+++ b/.github/workflows/model-image.yml
@@ -40,4 +40,4 @@ jobs:
       with:
         context: .
         file: ./Docker/Dockerfile-models
-        tags: yuanfornl/model-test:${{WORKSHOP_BRANCH}}-latest
+        tags: yuanfornl/model-test:${{env.WORKSHOP_BRANCH_TAG}}-latest

--- a/.github/workflows/vis-image.yml
+++ b/.github/workflows/vis-image.yml
@@ -40,4 +40,4 @@ jobs:
       with:
         context: .
         file: ./Docker/Dockerfile-vis
-        tags: yuanfornl/vis-test:${{WORKSHOP_BRANCH}}-latest
+        tags: yuanfornl/vis-test:${{env.WORKSHOP_BRANCH_TAG}}-latest


### PR DESCRIPTION
Note: expecting the vis image to fail until https://github.com/conda-forge/ilamb-feedstock/pull/23 is merged.