### PR TITLE
Add -y flag to ilamb-fetch to avoid interactive input.

### DIFF
--- a/tools/scripts/get_inputdata.sh
+++ b/tools/scripts/get_inputdata.sh
@@ -18,6 +18,6 @@ if [ -d "/mnt/inputdata/ILAMB/DATA" ]; then
 else
  mkdir -p /mnt/inputdata/ILAMB
  mkdir -p /mnt/inputdata/ILAMB/DATA
- ilamb-fetch --local_root=/mnt/inputdata/ILAMB/DATA --remote_root=https://data.ngee-arctic.ornl.gov/ilamb/DATA --collection=NGEEA-Workshop --no-check-certificate
+ ilamb-fetch -y --local_root=/mnt/inputdata/ILAMB/DATA --remote_root=https://data.ngee-arctic.ornl.gov/ilamb/DATA --collection=NGEEA-Workshop --no-check-certificate
 fi
 


### PR DESCRIPTION
Add -y flag to ilamb-fetch to avoid interactive input.